### PR TITLE
Allow archived deletes for admins

### DIFF
--- a/src/main/java/org/epos/backoffice/api/util/EPOSDataModelManager.java
+++ b/src/main/java/org/epos/backoffice/api/util/EPOSDataModelManager.java
@@ -726,6 +726,69 @@ public class EPOSDataModelManager {
         }
     }
 
+    /**
+     * Checks if a user can DELETE an entity.
+     */
+    private static boolean checkUserPermissionsDelete(EPOSDataModelEntity obj, User user) {
+        if (user.getIsAdmin()) {
+            return true;
+        }
+        return checkUserPermissionsDelete(obj, user, getUserAcceptedGroupRoles(user));
+    }
+
+    /**
+     * Checks if a user can DELETE an entity using pre-fetched user group roles.
+     */
+    private static boolean checkUserPermissionsDelete(EPOSDataModelEntity obj, User user, Map<String, String> userGroupRoles) {
+        // Backoffice admin has full access to everything
+        if (user.getIsAdmin()) {
+            return true;
+        }
+
+        // Entities without groups are only accessible to backoffice admins
+        if (obj.getGroups() == null || obj.getGroups().isEmpty()) {
+            return false;
+        }
+
+        // Get user's role in the entity's groups using pre-fetched map
+        String userRole = getUserRoleInEntityGroups(obj, userGroupRoles);
+
+        // No membership in entity's groups = external user = no access
+        if (userRole == null) {
+            return false;
+        }
+
+        // Group ADMIN has full access within their groups
+        if (RoleType.ADMIN.name().equals(userRole)) {
+            return true;
+        }
+
+        // Check if user is the owner (for "self" permissions)
+        boolean isOwner = user.getAuthIdentifier() != null &&
+                          user.getAuthIdentifier().equals(obj.getEditorId());
+
+        StatusType status = obj.getStatus();
+        if (status == null) {
+            status = StatusType.DRAFT;
+        }
+
+        switch (status) {
+            case DRAFT:
+                return RoleType.EDITOR.name().equals(userRole);
+
+            case SUBMITTED:
+                return RoleType.REVIEWER.name().equals(userRole)
+                        || (RoleType.EDITOR.name().equals(userRole) && isOwner);
+
+            case PUBLISHED:
+            case DISCARDED:
+                return RoleType.REVIEWER.name().equals(userRole);
+
+            default:
+                return false;
+        }
+    }
+
     private static boolean hasReviewerRole(User user, EPOSDataModelEntity obj) {
         if(obj.getGroups() != null && !obj.getGroups().isEmpty()){
             for(String groupid : obj.getGroups()){
@@ -804,7 +867,7 @@ public class EPOSDataModelManager {
             return new ApiResponseMessage(ApiResponseMessage.ERROR, "Entity not found");
         }
         
-        if(!checkUserPermissionsReadWrite(existingEntity, user)) {
+        if(!checkUserPermissionsDelete(existingEntity, user)) {
             log.warn("Entity delete denied userId={} entityType={} instanceId={} status={} groups={}",
                     userId,
                     entityNames.name(),

--- a/src/test/java/org/epos/backoffice/api/controller/EntityManagementOperationMappingTest.java
+++ b/src/test/java/org/epos/backoffice/api/controller/EntityManagementOperationMappingTest.java
@@ -1,19 +1,22 @@
 package org.epos.backoffice.api.controller;
 
-import abstractapis.AbstractAPI;
-import commonapis.LinkedEntityAPI;
-import metadataapis.EntityNames;
-import model.StatusType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
 import org.epos.backoffice.api.util.EPOSDataModelManager;
 import org.epos.backoffice.api.util.UserManager;
-import org.epos.eposdatamodel.*;
+import org.epos.eposdatamodel.LinkedEntity;
+import org.epos.eposdatamodel.Mapping;
+import org.epos.eposdatamodel.Operation;
+import org.epos.eposdatamodel.User;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
+import commonapis.LinkedEntityAPI;
+import metadataapis.EntityNames;
+import model.StatusType;
 
 public class EntityManagementOperationMappingTest extends TestcontainersLifecycle {
 
@@ -44,12 +47,6 @@ public class EntityManagementOperationMappingTest extends TestcontainersLifecycl
         operation.setReturns(List.of("application/json"));
         operation.setStatus(StatusType.DRAFT);
 
-        LinkedEntity operationLinkedEntity = EPOSDataModelManager.createEposDataModelEntity(operation, user, EntityNames.OPERATION, Operation.class).getEntity();
-
-        operation.setInstanceId(operationLinkedEntity.getInstanceId());
-        operation.setMetaId(operationLinkedEntity.getMetaId());
-        operation.setUid(operationLinkedEntity.getUid());
-
         Mapping mapping1 = new Mapping();
         mapping1.setVariable("test1");
         mapping1.setLabel("label1");
@@ -57,14 +54,10 @@ public class EntityManagementOperationMappingTest extends TestcontainersLifecycl
 
         LinkedEntity mapping1LinkedEntity = EPOSDataModelManager.createEposDataModelEntity(mapping1, user, EntityNames.MAPPING, Mapping.class).getEntity();
 
-        mapping1.setInstanceId(operationLinkedEntity.getInstanceId());
-        mapping1.setMetaId(operationLinkedEntity.getMetaId());
-        mapping1.setUid(operationLinkedEntity.getUid());
-
         operation.setMapping(List.of(mapping1LinkedEntity));
 
         System.out.println(operation);
-        operationLinkedEntity = EPOSDataModelManager.createEposDataModelEntity(operation, user, EntityNames.OPERATION, Operation.class).getEntity();
+        LinkedEntity operationLinkedEntity = EPOSDataModelManager.createEposDataModelEntity(operation, user, EntityNames.OPERATION, Operation.class).getEntity();
 
         assertEquals(1, ((Operation)LinkedEntityAPI.retrieveFromLinkedEntity(operationLinkedEntity)).getMapping().size());
 


### PR DESCRIPTION
Fix delete permission check so backoffice admin and group admin can delete archived entities in their group.

Why: delete reused write permissions, which blocked archived deletions with 403.